### PR TITLE
Add test MkDocs site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ dev = [
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
     "ruff>=0.14.5",
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.7.0",
+    "pymdown-extensions>=10.17.1",
 ]

--- a/tmp/test-mkdocs/docs/index.md
+++ b/tmp/test-mkdocs/docs/index.md
@@ -1,0 +1,11 @@
+# Test Documentation
+
+Welcome to the test site.
+
+- [Internal link to Page 1](page1.md)
+- [Anchor link](#heading)
+- [External link](https://www.example.com)
+
+## Heading
+
+This is a section with a heading for anchor link testing.

--- a/tmp/test-mkdocs/docs/page1.md
+++ b/tmp/test-mkdocs/docs/page1.md
@@ -1,0 +1,7 @@
+# Page 1
+
+Link back to [home](index.md).
+
+Link to [Page 2](page2.md).
+
+Link to [anchor on Page 2](page2.md#section).

--- a/tmp/test-mkdocs/docs/page2.md
+++ b/tmp/test-mkdocs/docs/page2.md
@@ -1,0 +1,5 @@
+# Page 2
+
+## Section
+
+Content here.

--- a/tmp/test-mkdocs/mkdocs.yml
+++ b/tmp/test-mkdocs/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: Test Documentation
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.superfences
+  - pymdownx.details
+  - toc:
+      title: On this page
+
+nav:
+  - Home: index.md
+  - Page 1: page1.md
+  - Page 2: page2.md


### PR DESCRIPTION
## Summary

Implements Phase 1 of Docker Compose MkDocs setup by creating a minimal test site with Material theme for development and testing.

## Changes

- Created test site structure in tmp/test-mkdocs/
- Added mkdocs.yml with Material theme configuration
- Added three sample markdown pages demonstrating:
  - Internal page links
  - Anchor links within pages
  - External links
- Added MkDocs dependencies to pyproject.toml (mkdocs, mkdocs-material, pymdown-extensions)

## Testing

- Verified MkDocs build completes successfully with exit code 0
- Verified generated HTML contains proper link structure
- Verified MkDocs serve runs and serves content on port 8000
- All pre-commit hooks pass (black, ruff, pytest)

## Notes

The mkdocs-privacy-plugin was not available in PyPI, so only the search plugin was configured. This does not affect the test site functionality for Docker development purposes.

Resolves #1